### PR TITLE
Fixes queries helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ to build an image, follow the next steps:
 2. run the following command to build the image:
 
 ```sh
-$ docker build -f Dockerfile.prod -t d3_growth_backend:1.0.0 .
+$ docker build -f Dockerfile.prod -t d3_growth_backend:1.0.1 .
 ```
 
 3. then, you can start the container:
 
 ```sh
-$ docker run -it -p 3000:3000 --name d3_growth_backend d3_growth_backend:1.0.0
+$ docker run -it -p 3000:3000 --name d3_growth_backend d3_growth_backend:1.0.1
 ```

--- a/app/data/answers.js
+++ b/app/data/answers.js
@@ -103,13 +103,11 @@ module.exports = {
   },
 
   getRelated(db, term) {
-    const query = [...queriesHelper.termToQuery(term), { normalizedComment: { $ne: null } }]
+    const $and = queriesHelper.termToQuery(term)
 
     return new Promise((resolve, reject) => {
       db.collection(COLLECTION_NAME)
-        .find({
-          $and: query
-        })
+        .find({ $and })
         .project({ _id: 0, normalizedComment: 0 })
         .toArray((err, answers) => {
           if (err) {

--- a/app/data/answers.js
+++ b/app/data/answers.js
@@ -1,3 +1,5 @@
+const moment = require('moment')
+
 const answersHelper = require('../helpers/answers')
 const queriesHelper = require('../helpers/queries')
 
@@ -64,8 +66,11 @@ module.exports = {
 
   getNps(db) {
     return new Promise((resolve, reject) => {
+      const today = moment().format('YYYY-MM-DD')
+      const $match = { $and: queriesHelper.rangeToQuery(today, today) }
+
       db.collection(COLLECTION_NAME)
-        .aggregate([{ $group: { _id: '$type', count: { $sum: 1 } } }])
+        .aggregate([{ $match }, { $group: { _id: '$type', count: { $sum: 1 } } }])
         .toArray((err, doc) => {
           if (err) {
             return reject(err)

--- a/app/helpers/queries.js
+++ b/app/helpers/queries.js
@@ -5,7 +5,7 @@ const answersHelper = require('./answers')
 module.exports = {
   termToQuery(term) {
     const normalizedTerm = answersHelper.normalizeAnswerString(term)
-    const defaultQuery = [{ normalizedComment: { $ne: null } }]
+    const defaultQuery = [{ comment: { $ne: null } }]
 
     if (!normalizedTerm) {
       return defaultQuery
@@ -23,7 +23,7 @@ module.exports = {
 
   categoriesToQuery(categories) {
     if (!categories) {
-      return [{}]
+      return []
     }
 
     return `${categories}`
@@ -82,9 +82,15 @@ module.exports = {
     const $and = [...this.termToQuery(term), ...this.rangeToQuery(startDate, endDate)]
     const $or = [...this.categoriesToQuery(categories)]
 
-    return {
-      $and,
-      $or
+    const query = { $and }
+
+    if ($or.length) {
+      return {
+        ...query,
+        $or
+      }
     }
+
+    return query
   }
 }

--- a/app/helpers/queries.js
+++ b/app/helpers/queries.js
@@ -5,16 +5,20 @@ const answersHelper = require('./answers')
 module.exports = {
   termToQuery(term) {
     const normalizedTerm = answersHelper.normalizeAnswerString(term)
+    const defaultQuery = [{ normalizedComment: { $ne: null } }]
 
     if (!normalizedTerm) {
-      return []
+      return defaultQuery
     }
 
-    return (`${normalizedTerm}`.trim().split(' ') || []).map(item => {
-      return {
-        normalizedComment: new RegExp(item)
-      }
-    })
+    return (`${normalizedTerm}`.trim().split(' ') || []).reduce((prev, current) => {
+      return [
+        ...prev,
+        {
+          normalizedComment: new RegExp(current)
+        }
+      ]
+    }, defaultQuery)
   },
 
   categoriesToQuery(categories) {

--- a/app/helpers/queries.js
+++ b/app/helpers/queries.js
@@ -37,15 +37,17 @@ module.exports = {
   },
 
   rangeToQuery(startDate, endDate) {
-    const start = moment(startDate || '1970-01-01')
+    const $gte = moment(startDate || '1970-01-01')
       .startOf('day')
-      .toISOString()
+      .add(3, 'hours')
+      .toDate()
 
-    const end = moment(endDate)
+    const $lte = moment(endDate)
       .endOf('day')
-      .toISOString()
+      .add(3, 'hours')
+      .toDate()
 
-    return [{ date: { $gte: new Date(start) } }, { date: { $lte: new Date(end) } }]
+    return [{ date: { $gte } }, { date: { $lte } }]
   },
 
   sortByToQuery(sortBy, direction) {

--- a/app/router/index.js
+++ b/app/router/index.js
@@ -10,7 +10,7 @@ const overview = require('./overview')
 router.use(cors.configure())
 
 router.use('/auth', auth)
-router.use('/version', (req, res) => res.send({ version: '1.0.0' }))
+router.use('/version', (req, res) => res.send({ version: '1.0.1' }))
 
 // router.use('/', passport.authenticate('bearer', { session: false })) # temporary
 router.use('/answers', answers)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-growth-back",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "a new experiment to growth process",
   "main": "index.js",
   "repository": "https://github.com/d3estudio/d3-growth-back",

--- a/tests/helpers/queries.test.js
+++ b/tests/helpers/queries.test.js
@@ -70,8 +70,12 @@ describe('app/helpers/queries', () => {
       })
 
       it('should return default query', () => {
-        const expectedStart = moment('1970-01-01').startOf('day')
-        const expectedEnd = moment().endOf('day')
+        const expectedStart = moment('1970-01-01')
+          .startOf('day')
+          .add(3, 'hours')
+        const expectedEnd = moment()
+          .endOf('day')
+          .add(3, 'hours')
 
         expect(moment(result[0]['date']['$gte']).isSame(expectedStart)).to.be.true
         expect(moment(result[1]['date']['$lte']).isSame(expectedEnd)).to.be.true
@@ -90,8 +94,8 @@ describe('app/helpers/queries', () => {
       })
 
       it('should return correct query', () => {
-        const expectedStart = start.startOf('day')
-        const expectedEnd = end.endOf('day')
+        const expectedStart = start.startOf('day').add(3, 'hours')
+        const expectedEnd = end.endOf('day').add(3, 'hours')
 
         expect(moment(result[0]['date']['$gte']).isSame(expectedStart)).to.be.true
         expect(moment(result[1]['date']['$lte']).isSame(expectedEnd)).to.be.true

--- a/tests/helpers/queries.test.js
+++ b/tests/helpers/queries.test.js
@@ -12,21 +12,27 @@ describe('app/helpers/queries', () => {
     it('should return correct query for term "abc"', () => {
       const term = 'abc'
 
-      queriesHelper.termToQuery(term).should.have.length(1)
+      queriesHelper.termToQuery(term).should.have.length(2)
+
       queriesHelper.termToQuery(term)[0].should.have.property('normalizedComment')
-      queriesHelper.termToQuery(term)[0]['normalizedComment'].test('abc').should.be.true
+      queriesHelper.termToQuery(term)[0]['normalizedComment'].should.have.property('$ne')
+
+      queriesHelper.termToQuery(term)[1].should.have.property('normalizedComment')
+      queriesHelper.termToQuery(term)[1]['normalizedComment'].test('abc').should.be.true
     })
 
     it('should return correct query for term "abc"', () => {
       const term = 'a b c'
 
-      queriesHelper.termToQuery(term).should.have.length(3)
+      queriesHelper.termToQuery(term).should.have.length(4)
 
       queriesHelper.termToQuery(term)[0].should.have.property('normalizedComment')
+      queriesHelper.termToQuery(term)[0]['normalizedComment'].should.have.property('$ne')
 
-      queriesHelper.termToQuery(term)[0]['normalizedComment'].test('a').should.be.true
-      queriesHelper.termToQuery(term)[1]['normalizedComment'].test('a').should.be.false
+      queriesHelper.termToQuery(term)[1].should.have.property('normalizedComment')
+      queriesHelper.termToQuery(term)[1]['normalizedComment'].test('a').should.be.true
       queriesHelper.termToQuery(term)[2]['normalizedComment'].test('a').should.be.false
+      queriesHelper.termToQuery(term)[3]['normalizedComment'].test('a').should.be.false
     })
   })
 

--- a/tests/helpers/queries.test.js
+++ b/tests/helpers/queries.test.js
@@ -14,8 +14,8 @@ describe('app/helpers/queries', () => {
 
       queriesHelper.termToQuery(term).should.have.length(2)
 
-      queriesHelper.termToQuery(term)[0].should.have.property('normalizedComment')
-      queriesHelper.termToQuery(term)[0]['normalizedComment'].should.have.property('$ne')
+      queriesHelper.termToQuery(term)[0].should.have.property('comment')
+      queriesHelper.termToQuery(term)[0]['comment'].should.have.property('$ne')
 
       queriesHelper.termToQuery(term)[1].should.have.property('normalizedComment')
       queriesHelper.termToQuery(term)[1]['normalizedComment'].test('abc').should.be.true
@@ -26,8 +26,8 @@ describe('app/helpers/queries', () => {
 
       queriesHelper.termToQuery(term).should.have.length(4)
 
-      queriesHelper.termToQuery(term)[0].should.have.property('normalizedComment')
-      queriesHelper.termToQuery(term)[0]['normalizedComment'].should.have.property('$ne')
+      queriesHelper.termToQuery(term)[0].should.have.property('comment')
+      queriesHelper.termToQuery(term)[0]['comment'].should.have.property('$ne')
 
       queriesHelper.termToQuery(term)[1].should.have.property('normalizedComment')
       queriesHelper.termToQuery(term)[1]['normalizedComment'].test('a').should.be.true
@@ -42,9 +42,7 @@ describe('app/helpers/queries', () => {
         const result = queriesHelper.categoriesToQuery()
 
         result.should.be.an('array')
-        result.should.have.lengthOf(1)
-
-        result[0].should.be.empty
+        result.should.be.empty
       })
     })
 
@@ -164,9 +162,14 @@ describe('app/helpers/queries', () => {
   })
 
   describe('requestParamsToQuery(params)', () => {
-    it('should have the correct keys', () => {
-      const keys = ['$and', '$or']
-      queriesHelper.requestParamsToQuery().should.have.all.keys(keys)
+    it('should have the correct properties', () => {
+      const and = '$and'
+      const or = '$or'
+
+      const result = queriesHelper.requestParamsToQuery()
+
+      result.should.have.property(and)
+      result.should.not.have.property(or)
     })
 
     describe('when the term is present', () => {
@@ -177,18 +180,22 @@ describe('app/helpers/queries', () => {
 
         const result = queriesHelper.requestParamsToQuery(params)
 
-        result['$and'][0].should.have.property('normalizedComment')
+        result['$and'][0].should.have.property('comment')
         result['$and'][1].should.have.property('normalizedComment')
+        result['$and'][2].should.have.property('normalizedComment')
       })
     })
 
     describe('when the categories is present', () => {
-      it('should have the correct property', () => {
+      it('should have the correct keys', () => {
+        const keys = ['$and', '$or']
         const params = {
           categories: 'client,technology,content'
         }
 
         const result = queriesHelper.requestParamsToQuery(params)
+
+        result.should.have.all.keys(keys)
 
         expect(result['$or'][0]['category']).to.equals('client')
         expect(result['$or'][1]['category']).to.equals('technology')


### PR DESCRIPTION
In some cases, the `queriesHelper` was returning with clause `$or` empty, which to mongoDB represents no filter, so every time that we query something, we got all the answers.